### PR TITLE
SYM-1659, principal IDs + email output

### DIFF
--- a/sym_community_scripts/identitystore_userids.py
+++ b/sym_community_scripts/identitystore_userids.py
@@ -57,7 +57,7 @@ class IdentityStore:
 
             users = response.get("Users", [])
 
-            if len(users) < 1:
+            if not users:
                 sys.exit(f"Could not find a UserId for Username: {username}")
 
             userdata.append([username, self.identitystore_id, users[0]["UserId"]])


### PR DESCRIPTION
This commit updates the identitystore_userids script to output the
emails and principal ids so this can be used to feed into `symflow
users patch`.

In this commit, we convert from argparse to click, add a tabulate
display output, and can both read in a file for input (overriding what
was supplied as arguments) and write the output to a CSV.

Signed-off-by: Joshua Timberman <joshua@symops.io>
